### PR TITLE
Gesture change

### DIFF
--- a/FA_UISplitViewController.podspec
+++ b/FA_UISplitViewController.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
 s.name             = "FA_UISplitViewController"
-s.version          = "0.1.1"
+s.version          = "0.2"
 s.summary          = "FA_UISplitViewController is a controller to manage and add an overlay menu above the UISplitView"
 s.description      = <<-DESC
 This contoller let you add an overlay menu above the UISplitViewController.

--- a/Pod/MillefeuilleviewController.swift
+++ b/Pod/MillefeuilleviewController.swift
@@ -300,7 +300,8 @@ open class MillefeuilleViewController: UIViewController {
     guard let nav = master.viewControllers.first as? UINavigationController else { return }
     guard let view = nav.viewControllers.first?.view else { return }
     
-    let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(MillefeuilleViewController.handlePanGesture(_:)))
+    let panGestureRecognizer = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(MillefeuilleViewController.handlePanGesture(_:)))
+    panGestureRecognizer.edges = [.left]
     panGestureRecognizer.delegate = self
     view.addGestureRecognizer(panGestureRecognizer)
   }
@@ -408,6 +409,14 @@ extension MillefeuilleViewController: UIGestureRecognizerDelegate {
     }
     
     return true
+  }
+  
+  public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    return gestureRecognizer is UIScreenEdgePanGestureRecognizer && otherGestureRecognizer is UIPanGestureRecognizer
+  }
+  
+  public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    return gestureRecognizer is UIScreenEdgePanGestureRecognizer && otherGestureRecognizer is UIPanGestureRecognizer
   }
 }
 


### PR DESCRIPTION
This PR changes the gesture to open the menu. Instead of a `UIPanGestureRecognizer` it uses a `UIScreenEdgePanGestureRecognizer` and implements gesture delegates to make this gesture works properly with any pan gesture in the children view controllers. 